### PR TITLE
fix: AllowedMethods instead of IgnoredMethods

### DIFF
--- a/config/rubocop-metrics.yml
+++ b/config/rubocop-metrics.yml
@@ -2,7 +2,7 @@ Metrics/BlockLength:
   Enabled: true
   CountComments: false
   Max: 75
-  IgnoredMethods: [describe, context, FactoryBot.define, factory ]
+  AllowedMethods: [describe, context, FactoryBot.define, factory]
 
 Metrics/AbcSize:
   Enabled: false


### PR DESCRIPTION
Fix for warning:

```
Warning: obsolete parameter `IgnoredMethods` (for `Metrics/BlockLength`) found in ~/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/rubocop-gp-4d390b6cdd2b/config/rubocop-metrics.yml `IgnoredMethods` has been renamed to `AllowedMethods` and/or `AllowedPatterns`.
```