### PR TITLE
feat: missing gems for rubocop-rspec v3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,43 +1,89 @@
 PATH
   remote: .
   specs:
-    rubocop-gp (0.0.2)
+    rubocop-gp (0.0.4)
       rubocop
+      rubocop-capybara
+      rubocop-factory_bot
       rubocop-performance
       rubocop-rails
       rubocop-rspec
+      rubocop-rspec_rails
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.0)
+    activesupport (7.1.3.4)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
     coderay (1.1.2)
-    jaro_winkler (1.5.4)
+    concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
+    drb (2.2.1)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
     method_source (0.9.2)
-    parallel (1.19.1)
-    parser (2.7.0.4)
-      ast (~> 2.4.0)
+    minitest (5.24.0)
+    mutex_m (0.2.0)
+    parallel (1.25.1)
+    parser (3.3.3.0)
+      ast (~> 2.4.1)
+      racc
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (2.2.2)
-    rainbow (3.0.0)
-    rubocop (0.79.0)
-      jaro_winkler (~> 1.5.1)
+    racc (1.8.0)
+    rack (3.1.3)
+    rainbow (3.1.1)
+    regexp_parser (2.9.2)
+    rexml (3.3.0)
+      strscan
+    rubocop (1.64.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-performance (1.5.2)
-      rubocop (>= 0.71.0)
-    rubocop-rails (2.3.2)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-capybara (2.20.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.25.1)
+      rubocop (~> 1.41)
+    rubocop-performance (1.21.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rails (2.25.0)
+      activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
-      rubocop (>= 0.68.1)
-    ruby-progressbar (1.10.1)
-    unicode-display_width (1.6.1)
+      rubocop (>= 1.33.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rspec (3.0.1)
+      rubocop (~> 1.61)
+    rubocop-rspec_rails (2.28.3)
+      rubocop (~> 1.40)
+    ruby-progressbar (1.13.0)
+    strscan (3.1.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   ruby

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,6 +1,8 @@
 require:
   - rubocop-gp
   - rubocop-rspec
+  - rubocop-rspec_rails
+  - rubocop-factory_bot
   - rubocop-rails
   - rubocop-performance
   - rubocop-capybara

--- a/lib/rubocop/gp/version.rb
+++ b/lib/rubocop/gp/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Gp
-    VERSION = '0.0.3'
+    VERSION = '0.0.4'
   end
 end

--- a/rubocop-gp.gemspec
+++ b/rubocop-gp.gemspec
@@ -29,4 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-performance'
   spec.add_dependency 'rubocop-rails'
   spec.add_dependency 'rubocop-rspec'
+  spec.add_dependency 'rubocop-capybara'
+  spec.add_dependency 'rubocop-factory_bot'
+  spec.add_dependency 'rubocop-rspec_rails'
 end


### PR DESCRIPTION
https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md

> 3.0.0 (2024-06-11)
> Remove extracted cops in Capybara, FactoryBot and Rails departments.