### PR TITLE
feat: no empty lines around class and module body

### DIFF
--- a/config/rubocop-layout.yml
+++ b/config/rubocop-layout.yml
@@ -18,14 +18,6 @@ Layout/EmptyLineBetweenDefs:
 Layout/EmptyLines:
   Enabled: false
 
-Layout/EmptyLinesAroundClassBody:
-  Enabled: true
-  EnforcedStyle: empty_lines
-
-Layout/EmptyLinesAroundModuleBody:
-  Enabled: true
-  EnforcedStyle: empty_lines_except_namespace
-
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: true
   EnforcedStyle: space


### PR DESCRIPTION
Предлагаю всё-таки сделать дефолтное `no_empty_lines`, сейчас файл сильно разбухает, если есть внутренние классы

- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLinesAroundClassBody
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLinesAroundModuleBody

Как вариант сделать кастомное правило, которое добавляет пустые строки только в модуле/классе верхнего уровня